### PR TITLE
Fix applying templates saved with legacy exercise names

### DIFF
--- a/app.js
+++ b/app.js
@@ -977,7 +977,15 @@ function normalizeExercise(exercise) {
     return null;
   }
 
-  const name = typeof exercise.exercise === 'string' ? exercise.exercise : '';
+  const nameSource =
+    typeof exercise.exercise === 'string'
+      ? exercise.exercise
+      : typeof exercise.name === 'string'
+      ? exercise.name
+      : typeof exercise.title === 'string'
+      ? exercise.title
+      : '';
+  const name = nameSource.trim();
 
   if (Array.isArray(exercise.sets)) {
     const sets = exercise.sets


### PR DESCRIPTION
## Summary
- trim and normalize exercise names when loading template data
- support legacy template entries that stored exercises under `name`/`title` fields so Apply fills them in

## Testing
- Manual verification: saved a template in the current UI and reapplied it
- Manual verification: injected a legacy template that only used `name` for exercise entries and applied it


------
https://chatgpt.com/codex/tasks/task_e_68d16ec3e8d8832e91f8e76a01b97a74