### PR TITLE
Restyle exercise set cards for compact layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,19 +174,23 @@
 
   <template id="setRowTemplate">
     <div class="set-row" role="listitem">
-      <span class="set-label">Set</span>
-      <label>
-        <span>Reps</span>
-        <input type="number" name="reps" min="1" max="50" inputmode="numeric" required />
-      </label>
-      <label>
-        <span>Weight</span>
-        <div class="weight-input">
-          <input type="number" name="weight" min="0" step="0.5" inputmode="decimal" placeholder="0" />
-          <span class="unit" aria-hidden="true">kg</span>
-        </div>
-      </label>
-      <button type="button" class="icon-button remove-set" aria-label="Remove set">✕</button>
+      <div class="set-row-header">
+        <span class="set-label">Set</span>
+        <button type="button" class="icon-button remove-set" aria-label="Remove set">✕</button>
+      </div>
+      <div class="set-row-fields">
+        <label>
+          <span>Reps</span>
+          <input type="number" name="reps" min="1" max="50" inputmode="numeric" required />
+        </label>
+        <label>
+          <span>Weight</span>
+          <div class="weight-input">
+            <input type="number" name="weight" min="0" step="0.5" inputmode="decimal" placeholder="0" />
+            <span class="unit" aria-hidden="true">kg</span>
+          </div>
+        </label>
+      </div>
     </div>
   </template>
 

--- a/styles.css
+++ b/styles.css
@@ -375,45 +375,108 @@ body.dark-theme .exercise-row {
 
 .set-list {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.65rem;
+}
+
+@media (min-width: 640px) {
+  .set-list {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
 }
 
 .set-row {
   display: grid;
-  grid-template-columns: auto repeat(2, minmax(0, 1fr)) auto;
-  gap: 0.75rem;
-  align-items: center;
-  padding: 0.75rem;
+  gap: 0.55rem;
+  padding: 0.65rem 0.75rem;
   border-radius: var(--radius-sm);
-  background: rgba(15, 76, 129, 0.06);
+  border: 1px solid rgba(15, 76, 129, 0.08);
+  background: rgba(15, 76, 129, 0.05);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  transition: border-color var(--transition), box-shadow var(--transition),
+    background var(--transition);
 }
 
 body.dark-theme .set-row {
-  background: rgba(40, 68, 104, 0.35);
+  background: rgba(40, 68, 104, 0.4);
+  border-color: rgba(140, 200, 255, 0.16);
+  box-shadow: inset 0 1px 0 rgba(4, 11, 18, 0.6);
 }
 
-.set-row label {
-  display: grid;
-  gap: 0.35rem;
-  font-size: 0.9rem;
+.set-row:focus-within {
+  border-color: rgba(40, 161, 255, 0.45);
+  box-shadow: 0 0 0 3px rgba(40, 161, 255, 0.16);
+  background: rgba(40, 161, 255, 0.08);
+}
+
+body.dark-theme .set-row:focus-within {
+  border-color: rgba(140, 200, 255, 0.55);
+  box-shadow: 0 0 0 3px rgba(40, 161, 255, 0.25);
+  background: rgba(40, 68, 104, 0.6);
+}
+
+.set-row-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .set-label {
-  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(15, 76, 129, 0.15);
   color: #0f4c81;
-  min-width: 48px;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 body.dark-theme .set-label {
-  color: #8cc8ff;
+  background: rgba(140, 200, 255, 0.22);
+  color: #e4f2ff;
 }
 
 .set-row .icon-button {
   margin-left: auto;
+  width: 28px;
+  height: 28px;
+}
+
+.set-row-fields {
+  display: grid;
+  gap: 0.55rem;
+}
+
+@media (min-width: 420px) {
+  .set-row-fields {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.set-row label {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+}
+
+.set-row label span {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--muted);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.set-row input[type="number"] {
+  padding: 0.55rem 0.65rem;
 }
 
 .exercise-row .add-set {
   justify-self: flex-start;
+  margin-top: 0.25rem;
 }
 
 .weight-input {
@@ -425,16 +488,26 @@ body.dark-theme .set-label {
   background: rgba(255, 255, 255, 0.9);
 }
 
+body.dark-theme .weight-input {
+  background: rgba(11, 23, 39, 0.9);
+}
+
 .weight-input input {
   border: none;
   flex: 1;
-  padding: 0.65rem 0.75rem;
+  padding: 0.55rem 0.65rem;
 }
 
 .weight-input .unit {
-  padding: 0.65rem 0.9rem;
+  padding: 0.55rem 0.75rem;
   background: rgba(15, 76, 129, 0.1);
   font-weight: 600;
+  font-size: 0.8rem;
+}
+
+body.dark-theme .weight-input .unit {
+  background: rgba(140, 200, 255, 0.18);
+  color: #e4f2ff;
 }
 
 button.primary,
@@ -680,16 +753,21 @@ button.small {
   }
 
   .set-row {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    align-items: stretch;
+    padding: 0.6rem 0.65rem;
   }
 
-  .set-label {
-    grid-column: 1 / -1;
+  .set-row-header {
+    gap: 0.3rem;
+  }
+
+  .set-row-fields {
+    gap: 0.5rem;
+    grid-template-columns: 1fr;
   }
 
   .set-row .icon-button {
-    justify-self: end;
+    width: 26px;
+    height: 26px;
   }
 }
 


### PR DESCRIPTION
## Summary
- reorganize the exercise set template into a header and field grid for a cleaner card structure
- tighten spacing and styling for set cards, including multi-column layout support and focus/dark theme states

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d175f70078832ea1285063f45ae5cf